### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-DataNormalizer KEYWORD1
-Read           KEYWORD2
-ErrorCode      KEYWORD3
-RawValue       KEYWORD4
-setRawValue    KEYWORD5
-Value          KEYWORD6
+DataNormalizer	KEYWORD1
+Read	KEYWORD2
+ErrorCode	KEYWORD3
+RawValue	KEYWORD4
+setRawValue	KEYWORD5
+Value	KEYWORD6

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,12 @@
 DataNormalizer	KEYWORD1
+
+configure	KEYWORD2
+IndexOf	KEYWORD2
+Normalize	KEYWORD2
 Read	KEYWORD2
-ErrorCode	KEYWORD3
-RawValue	KEYWORD4
-setRawValue	KEYWORD5
-Value	KEYWORD6
+ReadAndNormalize	KEYWORD2
+SensorCount	KEYWORD2
+StatusCode	KEYWORD2
+
+Values	KEYWORD2
+Normalized	KEYWORD2


### PR DESCRIPTION
- Use correct field separator.
- Correct keywords.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords